### PR TITLE
Fix REQ-PS-01: Validate player names before starting (fixes #5)

### DIFF
--- a/script.js
+++ b/script.js
@@ -151,17 +151,29 @@ function generateKeyboard() {
 function startGame() {
     const p1Name = document.getElementById('player1Name').value.trim();
     const p2Name = document.getElementById('player2Name').value.trim();
-    
-    gameState.player1.name = p1Name || 'Player 1';
-    gameState.player2.name = p2Name || 'Player 2';
-    
+
+    // REQ-PS-01: Player names MUST be provided and MUST be different
+    if (!p1Name || !p2Name) {
+        alert('Both player names are required.');
+        return;
+    }
+
+    if (p1Name === p2Name) {
+        alert('Player names must be different.');
+        return;
+    }
+
+    gameState.player1.name = p1Name;
+    gameState.player2.name = p2Name;
+
     document.getElementById('player1Display').textContent = gameState.player1.name;
     document.getElementById('player2Display').textContent = gameState.player2.name;
-    
+
     document.getElementById('gameArea').style.display = 'block';
-    
+
     nextRound();
 }
+
 
 function nextRound() {
     if (wordBank.length === 0) {


### PR DESCRIPTION
Fixes #5 

### Summary
Implemented validation in the player setup to enforce REQ-PS-01.

The game now:
- Prevents starting if either player name is empty.
- Prevents starting if both players use the same name.
- Displays a clear alert message explaining the validation error.

### Technical Changes
- Updated `startGame()` in `script.js`.
- Added conditional checks before initializing game state.
- No changes made outside player setup logic.

### Result
Ensures proper gameplay clarity and prevents ambiguous scoring scenarios caused by identical player names.
